### PR TITLE
Adds a symbolic link to dagon.ini.sample from the tutorial directory.

### DIFF
--- a/docs/tutorial/dagon.ini.sample
+++ b/docs/tutorial/dagon.ini.sample
@@ -1,0 +1,1 @@
+../../dagon.ini.sample


### PR DESCRIPTION
This change allows to run "cp dagon.ini.sample dagon.ini" directly from the tutorial directory.